### PR TITLE
Default nosec_lines to dictionary instead of list

### DIFF
--- a/flake8_bandit.py
+++ b/flake8_bandit.py
@@ -112,7 +112,7 @@ class BanditTester(object):
             metaast=BanditMetaAst(),
             testset=BanditTestSet(BanditConfig(), profile=config.profile),
             debug=False,
-            nosec_lines=[],
+            nosec_lines={},
             metrics=Metrics(),
         )
         bnv.generic_visit(self.tree)


### PR DESCRIPTION
This PR provides a simple fix to the following issue I ran into when trying to run `bandit` on a `python` script via `flake8` from https://github.com/nastra/flake8-bandit/tree/fix-issue-with-latest-bandit

```
Traceback (most recent call last):
  File "/usr/local/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File "/usr/local/lib/python3.8/site-packages/flake8/main/application.py", line 375, in run
    self._run(argv)
  File "/usr/local/lib/python3.8/site-packages/flake8/main/application.py", line 364, in _run
    self.run_checks()
  File "/usr/local/lib/python3.8/site-packages/flake8/main/application.py", line 271, in run_checks
    self.file_checker_manager.run()
  File "/usr/local/lib/python3.8/site-packages/flake8/checker.py", line 311, in run
    self.run_serial()
  File "/usr/local/lib/python3.8/site-packages/flake8/checker.py", line 295, in run_serial
    checker.run_checks()
  File "/usr/local/lib/python3.8/site-packages/flake8/checker.py", line 597, in run_checks
    self.run_ast_checks()
  File "/usr/local/lib/python3.8/site-packages/flake8/checker.py", line 500, in run_ast_checks
    for (line_number, offset, text, _) in runner:
  File "/usr/local/lib/python3.8/site-packages/flake8_bandit.py", line 136, in run
    for warn in self._check_source():
  File "/usr/local/lib/python3.8/site-packages/flake8_bandit.py", line 118, in _check_source
    bnv.generic_visit(self.tree)
  File "/usr/local/lib/python3.8/site-packages/bandit/core/node_visitor.py", line 263, in generic_visit
    if self.pre_visit(item):
  File "/usr/local/lib/python3.8/site-packages/bandit/core/node_visitor.py", line 208, in pre_visit
    nosec_tests = self.nosec_lines.get(node.lineno)
AttributeError: 'list' object has no attribute 'get'
```

### How to reproduce

1. Create `sample.py` with the following content:
```python
def foo(a: str) -> List[str]:
    return a.split()


def function_with_try_except() -> None:
    try:
        foo("test")
    except Exception:
        pass
```

2. Build a docker environment with the specific `flake8-bandit`
Content of `Dockerfile`
```
FROM python:3.8-slim

RUN python -m pip install --no-cache-dir --upgrade pip \
  && python -m pip install --no-cache-dir https://github.com/nastra/flake8-bandit/archive/dfba03252ab83d5db2180fe5522816b730a5a993.tar.gz

COPY sample.py sample.py

CMD ["flake8", "sample.py"]
```
Build with `docker build -t flake8-bandit-bug .`

4. Run the container to observe the reported error
`docker run --rm flake8-bandit-bug`
